### PR TITLE
Fixes date input fields from pushing the popup calendar icon to the n…

### DIFF
--- a/uikit/custom/pw/pw-inputfields.less
+++ b/uikit/custom/pw/pw-inputfields.less
@@ -121,7 +121,7 @@
   input[type=number]:not(.uk-input),
   input[type=url]:not(.uk-input) {
     .uk-input();
-    // width: auto;
+      width: auto;
     &.InputfieldMaxWidth {
       width: 100%;
     }


### PR DESCRIPTION
…ext line

You will need to recompile the css after this commit.

Before:
![edit page about us pwoliver test 2017-09-29 17-11-17](https://user-images.githubusercontent.com/40570/31037951-7c284602-a539-11e7-8ede-abeac310af87.jpg)

After:
![edit page about us pwoliver test 2017-09-29 17-13-31](https://user-images.githubusercontent.com/40570/31037962-8e3c95b4-a539-11e7-87e0-ab68104a0710.jpg)

I noticed this when using Chrome.

Hope that helps