### PR TITLE
make getUikitCSS hookable

### DIFF
--- a/AdminThemeUikit.module
+++ b/AdminThemeUikit.module
@@ -982,7 +982,7 @@ class AdminThemeUikit extends AdminThemeFramework implements Module, Configurabl
 	 * @return string
 	 * 
 	 */
-	public function getUikitCSS() {
+	public function ___getUikitCSS() {
 		$config = $this->wire('config');
 		$cssURL = $this->get('cssURL');
 		$moduleInfo = self::getModuleInfo();

--- a/AdminThemeUikit.module
+++ b/AdminThemeUikit.module
@@ -961,7 +961,12 @@ class AdminThemeUikit extends AdminThemeFramework implements Module, Configurabl
 			$alt = "ProcessWire $config->version";
 		}
 		$class = 'pw-logo ' . ($native ? 'pw-logo-native' : 'pw-logo-custom');
-		$img = "<img class='$class' src='$logoURL' alt='$alt' />";
+
+		// add uk-svg if the logo is a svg file
+		// this makes it stylable via CSS/LESS
+		$info = pathinfo($logoURL);
+		$uksvg = $info['extension'] == 'svg' ? 'uk-svg' : '';
+		$img = "<img class='$class' src='$logoURL' alt='$alt' $uksvg />";
 		
 		return $img;
 	}


### PR DESCRIPTION
Hi @ryancramerdesign ,

I've developed a little module that makes it easy to customize the look and feel of AdminThemeUikit via LESS without setting up any LESS parsers. It is done via a new module that I'm up to share with the community soon that uses less.php for parsing.

The theme.less files is simply put inthe the AdminThemeUikit module config setting for the CSS file and therefore I need to hook this function to check if a LESS file is set, and if yes parse the LESS and return the CSS path of this file.

Thx